### PR TITLE
call inherited constructor from TLogifyAdapterBuffer.Create

### DIFF
--- a/Source/Logify.Adapter.Buffer.pas
+++ b/Source/Logify.Adapter.Buffer.pas
@@ -60,6 +60,7 @@ implementation
 
 constructor TLogifyAdapterBuffer.Create;
 begin
+  inherited Create;
   FBuffer := TStringList.Create;
 end;
 


### PR DESCRIPTION
Without that, TLogifyAdapterBuffer.Create sets minimum log level to Trace instead of Info as if the default logger constructor is used.

To verify, compare Debug and Buffer loggers from the demo - Debug doesn't log Trace messages while Buffer does (and I argue that it should not).
